### PR TITLE
Exclude libssh and libssl headers from umbrella header

### DIFF
--- a/NMSSH.podspec
+++ b/NMSSH.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |spec|
   spec.osx.deployment_target  = '10.7'
   spec.osx.vendored_libraries = 'NMSSH-OSX/Libraries/lib/libssh2.a', 'NMSSH-OSX/Libraries/lib/libssl.a', 'NMSSH-OSX/Libraries/lib/libcrypto.a'
   spec.osx.source_files       = 'NMSSH-OSX', 'NMSSH-OSX/**/*.h'
-  spec.osx.public_header_files  = 'NMSSH-OSX/**/*.h'
+  spec.osx.private_header_files  = 'NMSSH-OSX/**/*.h'
 
   spec.xcconfig = {
     "OTHER_LDFLAGS" => "-ObjC",


### PR DESCRIPTION
Under macOS, libssh and libssl headers should be included as private headers since public headers are imported in the umbrella header. These header files contain path based includes such as `# include <openssl/stack.h>` which break when compiled as a dependency of another pod because the header search paths are incorrect. See #201. This PR fixes #201.