### PR TITLE
Fix 'if (!self.port)' analyze warning

### DIFF
--- a/NMSSH/NMSSHHostConfig.m
+++ b/NMSSH/NMSSHHostConfig.m
@@ -34,7 +34,7 @@
     if (!self.user) {
         [self setUser:other.user];
     }
-    if (!self.port) {
+    if (![self.port boolValue]) {
         [self setPort:other.port];
     }
     [self setIdentityFiles:[self mergedArray:self.identityFiles

--- a/NMSSH/NMSSHHostConfig.m
+++ b/NMSSH/NMSSHHostConfig.m
@@ -34,7 +34,7 @@
     if (!self.user) {
         [self setUser:other.user];
     }
-    if (![self.port boolValue]) {
+    if (self.port == nil) {
         [self setPort:other.port];
     }
     [self setIdentityFiles:[self mergedArray:self.identityFiles


### PR DESCRIPTION
@Frugghi @Lejdborg 
Xcode 9 running on macOS High Sierra issues this warning when analyzing with an attached iOS 11.0.1 iPad:

> Pods/NMSSH/NMSSH/NMSSHHostConfig.m:37:10: Converting a pointer value of type 'NSNumber *' to a primitive boolean value; instead, either compare the pointer to nil or call -boolValue

This commit fixes it. Please review and merge.