### PR TITLE
Reporting success when reading file into output stream.

### DIFF
--- a/NMSSH/NMSFTP.h
+++ b/NMSSH/NMSFTP.h
@@ -171,8 +171,9 @@
  @param path An existing file path
  @param stream Stream to write bytes to
  @param progress Method called periodically with number of bytes downloaded and total file size. Returns NO to abort.
+ @return File read success
  */
-- (void)contentsAtPath:(nonnull NSString *)path toStream:(nonnull NSOutputStream *)stream progress:(BOOL (^_Nullable)(NSUInteger, NSUInteger))progress;
+- (BOOL)contentsAtPath:(nonnull NSString *)path toStream:(nonnull NSOutputStream *)stream progress:(BOOL (^_Nullable)(NSUInteger, NSUInteger))progress;
 
 /**
  Overwrite the contents of a file

--- a/NMSSH/NMSFTP.m
+++ b/NMSSH/NMSFTP.m
@@ -246,8 +246,8 @@
     }
 }
 
-- (void)contentsAtPath:(NSString *)path toStream:(NSOutputStream *)outputStream progress:(BOOL (^)(NSUInteger, NSUInteger))progress {
-    [self readContentsAtPath:path toStream:outputStream progress:progress];
+- (BOOL)contentsAtPath:(NSString *)path toStream:(NSOutputStream *)outputStream progress:(BOOL (^)(NSUInteger, NSUInteger))progress {
+    return [self readContentsAtPath:path toStream:outputStream progress:progress];
 }
 
 - (BOOL)readContentsAtPath:(NSString *)path toStream:(NSOutputStream *)outputStream progress:(BOOL (^)(NSUInteger, NSUInteger))progress {


### PR DESCRIPTION
Small addition to report the success of reading a file into an output stream. The current implementation fails silently.